### PR TITLE
CI: update tag-push workflow from template

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -2,47 +2,75 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# Runs on tag push, promotes draft release
+# Runs on tag push, validates and promotes draft release
 name: 'Release on Tag Push 🚀'
 
 # yamllint disable-line rule:truthy
 on:
   push:
     tags:
-      # Triggered only by semantic tags push
       - '**'
 
 permissions: {}
 
 jobs:
-  promote-release:
-    name: 'Promote Draft Release'
-    # yamllint disable-line rule:line-length
-    if: startsWith(github.ref, 'refs/tags/')
-    runs-on: 'ubuntu-24.04'
+  validate_tag:
+    name: 'Validate Tag'
+    # Skip tag deletion events
+    if: "!github.event.deleted"
+    runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
-    timeout-minutes: 3
+      contents: read
+    timeout-minutes: 5
+    outputs:
+      tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
       # Harden the runner used by this workflow
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@002fdce3c6a235733a90a27c80493a3241e56863  # v2.12.1
+      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
         with:
           egress-policy: audit
 
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
-
-      - name: 'Verify Pushed Tag'
-        # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/tag-push-verify-action@f9c6e753870c6405883be2ba18af05d075aaffe8  # v0.1.0
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
-          versioning: 'semver'
+          persist-credentials: false
+
+      - name: 'Verify pushed tag'
+        id: tag_validate
+        # yamllint disable-line rule:line-length
+        uses: lfreleng-actions/tag-validate-action@67695fa3d045917ca7ecc0f1d5f0cad03e231104  # v1.0.1
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          require_type: 'semver'
+          reject_development: 'true'
+          require_github: 'true'
+          # yamllint disable-line rule:line-length
+          require_signed: 'ssh,gpg-unverifiable'  # Cannot verify GPG without key
+
+  promote_release:
+    name: 'Promote Draft Release'
+    needs: validate_tag
+    runs-on: 'ubuntu-latest'
+    permissions:
+      contents: write
+    timeout-minutes: 5
+    steps:
+      # Harden the runner used by this workflow
+      # yamllint disable-line rule:line-length
+      - uses: step-security/harden-runner@6c3c2f2c1c457b00c10c4848d6f5491db3b629df  # v2.18.0
+        with:
+          egress-policy: audit
+
+      # yamllint disable-line rule:line-length
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: 'Promote draft release'
         # yamllint disable-line rule:line-length
-        uses: lfreleng-actions/draft-release-promote-action@d7e7df12e32fa26b28dbc2f18a12766482785399  # v0.1.2
+        uses: lfreleng-actions/draft-release-promote-action@cd7cf442875ecaea5dbb070d0de94f21ece107c8  # v0.1.3
         with:
           token: "${{ secrets.GITHUB_TOKEN }}"
-          tag: "${{ github.ref_name }}"
+          tag: "${{ needs.validate_tag.outputs.tag }}"
           latest: true


### PR DESCRIPTION
Update `tag-push.yaml` to the latest version from `actions-template`.

### Key changes

- **Split into two jobs for least-privilege permissions**
  - `validate_tag` job runs with `contents: read` — validates the tag
  - `promote_release` job runs with `contents: write` — promotes the draft release
  - Validation code no longer executes with write permissions
- **Replace `tag-push-verify-action`** with `tag-validate-action@v1.0.1`
  (new action with richer validation: `reject_development`, `require_github`,
  and `require_signed` enforce stricter tag gating than the previous workflow)
- **Bump `harden-runner`** to v2.18.0
- **Add `actions/checkout@v6.0.2`** to the `promote_release` job before the
  draft release promotion step
- **Set `persist-credentials: false`** on both checkout steps to reduce token
  exposure, since downstream actions receive tokens via explicit token inputs
- **Add `tag` output** exposing the validated tag name for downstream jobs
- **Add tag deletion guard** (`if: "!github.event.deleted"`) to skip
  workflow runs triggered by tag deletion events
- **Increase `timeout-minutes`** from 3 to 5