### PR TITLE
Fix: Restore calculator package and gosec path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,8 +22,8 @@ vendor/
 # Go workspace file
 go.work
 
-# Binary output
-calculator
+# Binary output (root-anchored so pkg/calculator stays tracked)
+/calculator
 
 # macOS
 .DS_Store

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ lint:
 		golangci-lint run; \
 	else \
 		echo "golangci-lint not found, installing..."; \
-		go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
+		$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest; \
 		golangci-lint run; \
 	fi
 
@@ -107,7 +107,7 @@ audit:
 		govulncheck ./...; \
 	else \
 		echo "govulncheck not found, installing..."; \
-		go install golang.org/x/vuln/cmd/govulncheck@latest; \
+		$(GOCMD) install golang.org/x/vuln/cmd/govulncheck@latest; \
 		govulncheck ./...; \
 	fi
 	@echo "Running gosec..."
@@ -115,7 +115,7 @@ audit:
 		gosec ./...; \
 	else \
 		echo "gosec not found, installing..."; \
-		go install github.com/securecodewarrior/gosec/v2/cmd/gosec@latest; \
+		$(GOCMD) install github.com/securego/gosec/v2/cmd/gosec@latest; \
 		gosec ./...; \
 	fi
 	@echo "Running staticcheck..."
@@ -123,7 +123,7 @@ audit:
 		staticcheck ./...; \
 	else \
 		echo "staticcheck not found, installing..."; \
-		go install honnef.co/go/tools/cmd/staticcheck@latest; \
+		$(GOCMD) install honnef.co/go/tools/cmd/staticcheck@latest; \
 		staticcheck ./...; \
 	fi
 
@@ -177,10 +177,10 @@ run: build
 # Development setup
 dev-setup:
 	@echo "Setting up development environment..."
-	$(GOGET) -u github.com/golangci/golangci-lint/cmd/golangci-lint
-	$(GOGET) -u golang.org/x/vuln/cmd/govulncheck
-	$(GOGET) -u github.com/securecodewarrior/gosec/v2/cmd/gosec
-	$(GOGET) -u honnef.co/go/tools/cmd/staticcheck
+	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+	$(GOCMD) install golang.org/x/vuln/cmd/govulncheck@latest
+	$(GOCMD) install github.com/securego/gosec/v2/cmd/gosec@latest
+	$(GOCMD) install honnef.co/go/tools/cmd/staticcheck@latest
 	$(GOMOD) tidy
 
 # Benchmark tests

--- a/README.md
+++ b/README.md
@@ -44,5 +44,5 @@ go build -o calculator main.go
 
 ## Dependencies
 
-- Go 1.21+
+- Go 1.25+
 - github.com/stretchr/testify for testing

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@
 
 module github.com/lfreleng-actions/test-go-project
 
-go 1.21
+go 1.25
 
 require github.com/stretchr/testify v1.8.4
 

--- a/pkg/calculator/calculator.go
+++ b/pkg/calculator/calculator.go
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+// Package calculator provides basic arithmetic operations for the
+// test fixture used by lfreleng-actions CI workflows and actions.
+package calculator
+
+import "errors"
+
+// ErrDivisionByZero reports an attempt to divide by zero.
+var ErrDivisionByZero = errors.New("division by zero")
+
+// Calculator performs basic arithmetic operations.
+type Calculator struct{}
+
+// New returns a Calculator ready for use.
+func New() *Calculator { return &Calculator{} }
+
+// Add returns the sum of a and b.
+func (c *Calculator) Add(a, b float64) float64 { return a + b }
+
+// Subtract returns a minus b.
+func (c *Calculator) Subtract(a, b float64) float64 { return a - b }
+
+// Multiply returns the product of a and b.
+func (c *Calculator) Multiply(a, b float64) float64 { return a * b }
+
+// Divide returns a divided by b, or an error when b is zero.
+func (c *Calculator) Divide(a, b float64) (float64, error) {
+	if b == 0 {
+		return 0, ErrDivisionByZero
+	}
+	return a / b, nil
+}

--- a/pkg/calculator/calculator_test.go
+++ b/pkg/calculator/calculator_test.go
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: 2026 The Linux Foundation
+
+package calculator
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdd(t *testing.T) {
+	calc := New()
+	assert.InDelta(t, 5.0, calc.Add(2, 3), 1e-9)
+	assert.InDelta(t, -1.0, calc.Add(2, -3), 1e-9)
+	assert.InDelta(t, 0.0, calc.Add(0, 0), 1e-9)
+}
+
+func TestSubtract(t *testing.T) {
+	calc := New()
+	assert.InDelta(t, -1.0, calc.Subtract(2, 3), 1e-9)
+	assert.InDelta(t, 5.0, calc.Subtract(2, -3), 1e-9)
+}
+
+func TestMultiply(t *testing.T) {
+	calc := New()
+	assert.InDelta(t, 6.0, calc.Multiply(2, 3), 1e-9)
+	assert.InDelta(t, 0.0, calc.Multiply(2, 0), 1e-9)
+	assert.InDelta(t, -6.0, calc.Multiply(2, -3), 1e-9)
+}
+
+func TestDivide(t *testing.T) {
+	calc := New()
+	result, err := calc.Divide(6, 3)
+	require.NoError(t, err)
+	assert.InDelta(t, 2.0, result, 1e-9)
+
+	_, err = calc.Divide(1, 0)
+	require.ErrorIs(t, err, ErrDivisionByZero)
+}


### PR DESCRIPTION
## Summary

A bare `calculator` entry in `.gitignore` (intended for the built binary) also masked the `pkg/calculator/` source directory, so the package that `main.go` imports was never committed. This left the repository unable to build, breaking its role as a Go CI test fixture for the lfreleng-actions estate.

## Changes

- Anchor the `.gitignore` entry to the repository root (`calculator` → `/calculator`) so `pkg/calculator/` stays tracked
- Restore `pkg/calculator/calculator.go` with the operations `main.go` expects (add, subtract, multiply, divide with a division-by-zero error path)
- Add unit tests (`calculator_test.go`) covering all operations, including the error path
- Bump `go.mod` from `go 1.21` to `go 1.25`, matching the Go versions exercised by CI matrices across the organisation
- Correct the gosec install path in the `Makefile` (`securecodewarrior` → `securego`), which pointed at a non-existent module and broke `make audit` / `make dev-setup`

## Verification

- `go build ./...`, `go test ./...` and `go vet ./...` pass locally
- `prek run --all-files` passes clean

This unblocks using the repository as a fixture in the upcoming `go-workflows` reusable-workflow test matrix.