### PR TITLE
Chore: Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,28 @@
+---
+# SPDX-FileCopyrightText: 2026 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "CI(actions)"
+    # Wait before opening a bump PR so we don't churn on a release
+    # that gets retracted or superseded shortly after it ships.
+    # This is required to satisfy the zizmor workflow auditing tool.
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Chore"
+    cooldown:
+      default-days: 7
+    open-pull-requests-limit: 15


### PR DESCRIPTION
## Why

This repository had no Dependabot configuration, so it received no dependency updates at all and sat outside the release-age cooldown applied across the organisation. Of 117 non-archived repositories, 110 already carry one.

Two ecosystems apply: `github-actions` for the workflows, and `gomod` for `go.mod`. Both use the standard seven-day cooldown.

`github-releases-test-fixture` was the other repository flagged as missing a cooldown, but it contains a single `README.md` — no workflows, no manifests, no `.github` directory. A Dependabot config there would have nothing to update, so it is deliberately left alone.
