### PR TITLE
Docs: Trim the calculator package comment

### DIFF
--- a/pkg/calculator/calculator.go
+++ b/pkg/calculator/calculator.go
@@ -1,8 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 // SPDX-FileCopyrightText: 2026 The Linux Foundation
 
-// Package calculator provides basic arithmetic operations for the
-// test fixture used by lfreleng-actions CI workflows and actions.
+// Package calculator provides basic arithmetic operations.
 package calculator
 
 import "errors"


### PR DESCRIPTION
Clears the `ai-slop/narrative-comment` finding, taking the repository
to a clean aislop score of 100.

## What was wrong

```go
// Package calculator provides basic arithmetic operations for the
// test fixture used by lfreleng-actions CI workflows and actions.
package calculator
```

The second clause described where the package is *consumed* rather
than what it does. aislop flags that as cross-reference commentary, and
the objection holds: the statement dates the moment consumers change,
and nothing updates it when they do. Go doc comments describe the
package itself; the repository name and README already establish that
this is a fixture.

## The fix

```go
// Package calculator provides basic arithmetic operations.
package calculator
```

The first clause already said what the package provides, so nothing
informative is lost.

## Validation

`aislop ci` reports score 100 with no findings, using the bundled
`ruff` 0.15.4 and `golangci-lint` 2.10.1 that
`aislop-scan-action@v0.2.7` now provisions — worth noting this is the
first scan of this repository with the Go engine actually running.
`go build ./...` and `go test ./...` both pass.
