### PR TITLE
CI: Add release drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -1,0 +1,46 @@
+---
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+# SPDX-License-Identifier: Apache-2.0
+
+name: 'Release Drafter'
+
+# yamllint disable-line rule:truthy
+on:
+  push:
+    branches:
+      - main
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  update_release_draft:
+    name: 'Update Release Draft'
+    permissions:
+      contents: write  # Create and update draft releases
+      pull-requests: read  # Collect merged PRs for the draft notes
+    runs-on: 'ubuntu-latest'
+    timeout-minutes: 3
+    steps:
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
+      # yamllint disable-line rule:line-length
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
+        with:
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
+
+      # yamllint disable-line rule:line-length
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9  # v7.7.0


### PR DESCRIPTION
## Problem

This repository does not create draft releases, so pushing a tag yields
no curated release notes.

Investigation of the git history shows the release-drafter workflow was
never removed — it was **never present**:

- The initial commit (`a86ccfd`, June 2025) contained only
  `build-test.yml`; the repository was not seeded with the template's
  workflow set.
- Later template syncs copied `tag-push.yaml` (the *promote* half of
  the release pipeline, since replaced by the thin `release.yaml`
  caller) but never its companion `release-drafter.yaml` (the *create*
  half).
- Organisation rulesets cannot cover this gap: they only invoke
  workflows on pull request events, while the drafter must trigger on
  `push` to `main` to accumulate notes as PRs merge.

Without a drafter, the reusable release workflow falls back to
auto-creating a bare draft at tag time, losing the categorised notes
release-drafter builds up between releases.

## Change

Add `.github/workflows/release-drafter.yaml`, taken verbatim from
`actions-template` `main`. The drafter configuration resolves from the
organisation-level `.github` repository, matching the template's
current arrangement (the per-repo config was intentionally removed
there).

## Validation

- `zizmor --persona=auditor` on the new workflow: zero findings
- All pre-commit hooks passed (yamllint, actionlint, reuse, etc.)